### PR TITLE
Make Rust stable friendly by disabling bench by default 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["hatoo <hato2000@gmail.com>"]
 edition = "2018"
 
+[lib]
+bench = false
+
 [dependencies]
 
 [dev-dependencies]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,8 @@
 #![feature(test)]
 
-use bitset_fixed::BitSet;
 extern crate test;
+
+use bitset_fixed::BitSet;
 
 #[bench]
 fn bench_bitset_dp(b: &mut test::Bencher) {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,46 @@
+#![feature(test)]
+
+use bitset_fixed::BitSet;
+extern crate test;
+
+#[bench]
+fn bench_bitset_dp(b: &mut test::Bencher) {
+    use rand::prelude::*;
+    let size = 1000;
+    let mut v = Vec::new();
+    let mut rng = StdRng::seed_from_u64(114514);
+
+    for _ in 0..size {
+        v.push(rng.next_u32() as usize % size);
+    }
+
+    b.iter(|| {
+        let mut bset = BitSet::new(100000);
+        bset.set(0, true);
+
+        for &x in &v {
+            bset |= &(&bset << x);
+        }
+    });
+}
+
+#[bench]
+fn bench_bitset_dp_shl_or(b: &mut test::Bencher) {
+    use rand::prelude::*;
+    let size = 1000;
+    let mut v = Vec::new();
+    let mut rng = StdRng::seed_from_u64(114514);
+
+    for _ in 0..size {
+        v.push(rng.next_u32() as usize % size);
+    }
+
+    b.iter(|| {
+        let mut bset = BitSet::new(100000);
+        bset.set(0, true);
+
+        for &x in &v {
+            bset.shl_or(x);
+        }
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
-#![feature(test)]
 #![allow(clippy::suspicious_op_assign_impl)]
-
-extern crate test;
 
 const TRUE: &bool = &true;
 const FALSE: &bool = &false;
@@ -442,46 +439,4 @@ fn test_bitset_chomp() {
     assert_eq!((&set1 | &set2).count_ones(), 4);
     assert_eq!((&set1 & &set2).count_ones(), 2);
     assert_eq!((&set1 ^ &set2).count_ones(), 2);
-}
-
-#[bench]
-fn bench_bitset_dp(b: &mut test::Bencher) {
-    use rand::prelude::*;
-    let size = 1000;
-    let mut v = Vec::new();
-    let mut rng = StdRng::seed_from_u64(114514);
-
-    for _ in 0..size {
-        v.push(rng.next_u32() as usize % size);
-    }
-
-    b.iter(|| {
-        let mut bset = BitSet::new(100000);
-        bset.set(0, true);
-
-        for &x in &v {
-            bset |= &(&bset << x);
-        }
-    });
-}
-
-#[bench]
-fn bench_bitset_dp_shl_or(b: &mut test::Bencher) {
-    use rand::prelude::*;
-    let size = 1000;
-    let mut v = Vec::new();
-    let mut rng = StdRng::seed_from_u64(114514);
-
-    for _ in 0..size {
-        v.push(rng.next_u32() as usize % size);
-    }
-
-    b.iter(|| {
-        let mut bset = BitSet::new(100000);
-        bset.set(0, true);
-
-        for &x in &v {
-            bset.shl_or(x);
-        }
-    });
 }


### PR DESCRIPTION
Currently, master branch will not compile with Rust stable due to `#![feature(test)]` in `lib.rs`.

```console
$ cargo +stable build
   Compiling bitset-fixed v0.1.0 (.../bitset-fixed)
error[E0554]: #![feature] may not be used on the stable release channel
 --> src/lib.rs:1:1
  |
1 | #![feature(test)]
  | ^^^^^^^^^^^^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0554`.
```

To make it compile with stable, this pull request moves `[bench]` related codes to `benches/bench.rs` and disable `bench` for `lib` target in `Cargo.toml`. Note that you can still run the benchmarks with Rust nightly.

```console
$ cargo +stable build
   Compiling bitset-fixed v0.1.0 (.../bitset-fixed)
    Finished dev [unoptimized + debuginfo] target(s) in 0.57s

$ cargo +nightly bench
   Compiling autocfg v0.1.4
   Compiling libc v0.2.58
   Compiling rand_core v0.4.0
   Compiling bitset-fixed v0.1.0 (.../bitset-fixed)
   Compiling rand_core v0.3.1
   Compiling rand_jitter v0.1.4
   Compiling rand_xorshift v0.1.1
   Compiling rand_hc v0.1.0
   Compiling rand_isaac v0.1.1
   Compiling rand_pcg v0.1.2
   Compiling rand_chacha v0.1.1
   Compiling rand v0.6.5
   Compiling rand_os v0.1.3
    Finished release [optimized] target(s) in 6.10s
     Running target/release/deps/bench-5d72c6a0cafc2194

running 2 tests
test bench_bitset_dp        ... bench:   2,378,672 ns/iter (+/- 29,514)
test bench_bitset_dp_shl_or ... bench:   2,255,832 ns/iter (+/- 8,134)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out
```
