### PR TITLE
Add field repository to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "bitset-fixed"
 version = "0.1.0"
 authors = ["hatoo <hato2000@gmail.com>"]
 edition = "2018"
+repository = "https://github.com/hatoo/bitset-fixed"
 
 [lib]
 bench = false


### PR DESCRIPTION
After this change, https://crates.io/crates/bitset-fixed will have a link to this repository.